### PR TITLE
#3 attempt fix for janky iphone claim checkboxes

### DIFF
--- a/client/app/bundles/common/_styles/buttons.js
+++ b/client/app/bundles/common/_styles/buttons.js
@@ -1,13 +1,16 @@
 import styled from 'styled-components';
+import { breakpoints } from 'common/_styles/breakpoints';
 
 export const EditButton = styled.button`
   color: var(--blue);
   border-color: #c8d6e1;
   padding: 0.3rem 1.5rem;
 
-  &:hover,
-  &:active {
-    background: #5d859d;
+  @media ${breakpoints.tabletPortraitAndUp} {
+    &:hover,
+    &:active {
+      background: #5d859d;
+    }
   }
 `;
 
@@ -16,8 +19,10 @@ export const DeleteButton = styled.button`
   border-color: #ddbfbf;
   padding: 0.3rem 1.5rem;
 
-  &:hover,
-  &:active {
-    background: #b74a4a;
+  @media ${breakpoints.tabletPortraitAndUp} {
+    &:hover,
+    &:active {
+      background: #b74a4a;
+    }
   }
 `;

--- a/client/app/bundles/common/_styles/global.js
+++ b/client/app/bundles/common/_styles/global.js
@@ -1,4 +1,5 @@
 import { createGlobalStyle } from 'styled-components';
+import { breakpoints } from 'common/_styles/breakpoints';
 
 // eslint-disable-next-line import/prefer-default-export
 export const GlobalStyle = createGlobalStyle`
@@ -37,9 +38,11 @@ export const GlobalStyle = createGlobalStyle`
     border-radius: 5px;
     padding: 0.5rem 1rem;
 
-    &:hover, &:active {
-      background: #aaa;
-      color: white;
+    @media ${breakpoints.tabletPortraitAndUp} {
+      &:hover, &:active {
+        background: #aaa;
+        color: white;
+      }
     }
 
     &:disabled {

--- a/client/app/bundles/pages/UserProfilePage/components/ClaimListItem/index.jsx
+++ b/client/app/bundles/pages/UserProfilePage/components/ClaimListItem/index.jsx
@@ -25,12 +25,12 @@ const ClaimListItem = (props) => {
             <IconContext.Provider value={iconContextValue}>
               {!isGot && (
                 <styled.CheckboxButton onClick={gotHandler}>
-                  <MdCheckBoxOutlineBlank />
+                  <MdCheckBoxOutlineBlank focusable="false" />
                 </styled.CheckboxButton>
               )}
               {isGot && (
                 <styled.CheckboxButton onClick={gotHandler}>
-                  <MdOutlineCheckBox />
+                  <MdOutlineCheckBox focusable="false" />
                 </styled.CheckboxButton>
               )}
             </IconContext.Provider>


### PR DESCRIPTION
Relates to #3 

Attempting fix for janky iphone by disabling active and hover styles.