### PR TITLE
Adjust claimlist

### DIFF
--- a/client/app/bundles/pages/UserProfilePage/components/ClaimList/index.jsx
+++ b/client/app/bundles/pages/UserProfilePage/components/ClaimList/index.jsx
@@ -66,22 +66,16 @@ const ClaimList = () => {
     setIsAdding(false);
   };
 
-  const gotHandler = (e) => {
-    const parent = e.currentTarget.closest('[data-item-index]');
-    const item = items.current[parent.dataset.itemIndex];
+  const gotHandler = (index) => {
+    const item = items.current[index];
 
     item.isGot = !item.isGot;
 
-    api
-      .setGiftGot({
-        gift: item,
-      })
-      .then((response) => {
-        const { success } = response;
-        if (success) {
-          setClaims(sortClaims(items.current));
-        }
-      });
+    api.setGiftGot({
+      gift: item,
+    });
+
+    return item.isGot;
   };
 
   const unClaimHandler = (e) => {

--- a/client/app/bundles/pages/UserProfilePage/components/ClaimListItem/index.jsx
+++ b/client/app/bundles/pages/UserProfilePage/components/ClaimListItem/index.jsx
@@ -16,6 +16,11 @@ const ClaimListItem = (props) => {
   const { title, priceLow, priceHigh, description, isGot } = gift;
 
   const [isExpanded, setIsExpanded] = useState(false);
+  const [showIsGot, setShowIsGot] = useState(isGot);
+
+  const gotClickHandler = () => {
+    setShowIsGot(gotHandler(index));
+  };
 
   return (
     <styled.Component data-item-index={index} isGot={isGot}>
@@ -23,13 +28,13 @@ const ClaimListItem = (props) => {
         <styled.SummaryRow>
           <styled.CheckboxContainer>
             <IconContext.Provider value={iconContextValue}>
-              {!isGot && (
-                <styled.CheckboxButton onClick={gotHandler}>
+              {!showIsGot && (
+                <styled.CheckboxButton onClick={gotClickHandler}>
                   <MdCheckBoxOutlineBlank focusable="false" />
                 </styled.CheckboxButton>
               )}
-              {isGot && (
-                <styled.CheckboxButton onClick={gotHandler}>
+              {showIsGot && (
+                <styled.CheckboxButton onClick={gotClickHandler}>
                   <MdOutlineCheckBox focusable="false" />
                 </styled.CheckboxButton>
               )}


### PR DESCRIPTION
Keep the current order of the list items when marking as got/not got. When the list reloads (re-renders, technically) the new order will have got items as lower down, but simply marking as got/not got will not rerender the entire list.